### PR TITLE
Upgrade to TRAPI v1.1

### DIFF
--- a/reasoner/cypher.py
+++ b/reasoner/cypher.py
@@ -129,10 +129,10 @@ def assemble_results(qnodes, qedges, **kwargs):
             "nodes: apoc.map.fromLists("
             "[n IN collect(DISTINCT knode) | n.id], "
             "[n IN collect(DISTINCT knode) | {"
-            "category: labels(n), name: n.name, "
+            "categories: labels(n), name: n.name, "
             "attributes: [key in apoc.coll.subtract(keys(n), "
             + cypher_expression.dumps(RESERVED_NODE_PROPS) +
-            ") | {name: key, type: COALESCE("
+            ") | {original_attribute_name: key, attribute_type_id: COALESCE("
             + cypher_expression.dumps(ATTRIBUTE_TYPES) +
             "[key], \"NA\"), value: n[key]}]}]), "
         )
@@ -147,7 +147,7 @@ def assemble_results(qnodes, qedges, **kwargs):
             "predicate: type(e), subject: startNode(e).id, object: endNode(e).id, "
             "attributes: [key in apoc.coll.subtract(keys(e), "
             + cypher_expression.dumps(RESERVED_EDGE_PROPS) +
-            ") | {name: key, type: COALESCE("
+            ") | {original_attribute_name: key, attribute_type_id: COALESCE("
             + cypher_expression.dumps(ATTRIBUTE_TYPES) +
             "[key], \"NA\"), value: e[key]}]}])"
         )

--- a/reasoner/matching.py
+++ b/reasoner/matching.py
@@ -35,8 +35,8 @@ class NodeReference():
 
         All node properties of types [str, bool, float/int] will be enforced
         verbatim EXCEPT for the following reserved properties:
-        * category
-        * id
+        * categories
+        * ids
         * name
         * is_set
         Un-reserved properties with other types will be coerced to str.
@@ -51,7 +51,7 @@ class NodeReference():
         self._filters = []
         self.labels = []
 
-        category = node.pop("category", None)
+        category = node.pop("categories", None)
         if isinstance(category, list) and len(category) == 1:
             category = category[0]
         if isinstance(category, list):
@@ -66,7 +66,7 @@ class NodeReference():
             # coerce to a string
             self.labels = [str(category)]
 
-        curie = node.pop("id", None)
+        curie = node.pop("ids", None)
         if isinstance(curie, list) and len(curie) == 1:
             curie = curie[0]
         if isinstance(curie, list):
@@ -149,7 +149,7 @@ class EdgeReference():
         """Create an edge reference."""
         self.name = edge_id if not anonymous else ""
         self.predicates: List[str] = ensure_list(
-            edge.get("predicate", []) or []
+            edge.get("predicates", []) or []
         )
         self.filters = []
         self.label = None
@@ -202,7 +202,7 @@ class EdgeReference():
         props.update(
             (key, value)
             for key, value in edge.items()
-            if key not in ("name", "predicate", "subject", "object")
+            if key not in ("name", "predicates", "subject", "object")
         )
 
         self.prop_string = " {" + ", ".join([

--- a/reasoner/matching.py
+++ b/reasoner/matching.py
@@ -147,9 +147,12 @@ class EdgeReference():
 
     def __init__(self, edge_id, edge, anonymous=False):
         """Create an edge reference."""
+        edge = dict(edge)  # make shallow copy
+        _subject = edge.pop("subject")
+        _object = edge.pop("object")
         self.name = edge_id if not anonymous else ""
         self.predicates: List[str] = ensure_list(
-            edge.get("predicates", []) or []
+            edge.pop("predicates", []) or []
         )
         self.filters = []
         self.label = None
@@ -188,12 +191,12 @@ class EdgeReference():
             self.directed = False
             self.filters.append(" OR ".join([
                 "(type({0}) = \"{1}\" AND startNode({0}) = `{2}`)".format(
-                    self.name, predicate, edge["subject"],
+                    self.name, predicate, _subject,
                 )
                 for predicate in self.predicates
             ] + [
                 "(type({0}) = \"{1}\" AND startNode({0}) = `{2}`)".format(
-                    self.name, predicate, edge["object"],
+                    self.name, predicate, _object,
                 )
                 for predicate in self.inverse_predicates
             ]))
@@ -202,7 +205,7 @@ class EdgeReference():
         props.update(
             (key, value)
             for key, value in edge.items()
-            if key not in ("name", "predicates", "subject", "object")
+            if key not in ("name",)
         )
 
         self.prop_string = " {" + ", ".join([

--- a/tests/test_compounds.py
+++ b/tests/test_compounds.py
@@ -13,14 +13,14 @@ def test_multiedge_or_complicated(database):
             "nodes": {
                 "n0": {},
                 "n1a": {
-                    "id": ["NCBIGene:836"]
+                    "ids": ["NCBIGene:836"]
                 },
             },
             "edges": {
                 "e10a": {
                     "subject": "n0",
                     "object": "n1a",
-                    "predicate": "biolink:genetic_association",
+                    "predicates": "biolink:genetic_association",
                 },
             },
         },
@@ -28,22 +28,22 @@ def test_multiedge_or_complicated(database):
             "nodes": {
                 "n0": {},
                 "n1b": {
-                    "id": "NCBIGene:841"
+                    "ids": "NCBIGene:841"
                 },
                 "n2b": {
-                    "id": "HP:0012592"
+                    "ids": "HP:0012592"
                 },
             },
             "edges": {
                 "e10b": {
                     "subject": "n0",
                     "object": "n1b",
-                    "predicate": "biolink:genetic_association",
+                    "predicates": "biolink:genetic_association",
                 },
                 "e20b": {
                     "subject": "n0",
                     "object": "n2b",
-                    "predicate": "biolink:has_phenotype",
+                    "predicates": "biolink:has_phenotype",
                 },
             },
         },
@@ -80,14 +80,14 @@ def test_complex_and(database):
                 "nodes": {
                     "n0": {},
                     "n1a": {
-                        "id": "NCBIGene:836"
+                        "ids": "NCBIGene:836"
                     },
                 },
                 "edges": {
                     "e10a": {
                         "subject": "n0",
                         "object": "n1a",
-                        "predicate": "biolink:genetic_association",
+                        "predicates": "biolink:genetic_association",
                     },
                 },
             },
@@ -95,14 +95,14 @@ def test_complex_and(database):
                 "nodes": {
                     "n0": {},
                     "n1b": {
-                        "id": "NCBIGene:841"
+                        "ids": "NCBIGene:841"
                     },
                 },
                 "edges": {
                     "e10b": {
                         "subject": "n0",
                         "object": "n1b",
-                        "predicate": "biolink:genetic_association",
+                        "predicates": "biolink:genetic_association",
                     },
                 },
             },
@@ -113,14 +113,14 @@ def test_complex_and(database):
                 "nodes": {
                     "n0": {},
                     "n2a": {
-                        "id": "HP:0012592"
+                        "ids": "HP:0012592"
                     },
                 },
                 "edges": {
                     "e20a": {
                         "subject": "n0",
                         "object": "n2b",
-                        "predicate": "biolink:has_phenotype",
+                        "predicates": "biolink:has_phenotype",
                     },
                 },
             },
@@ -128,14 +128,14 @@ def test_complex_and(database):
                 "nodes": {
                     "n0": {},
                     "n2b": {
-                        "id": "HP:0004324"
+                        "ids": "HP:0004324"
                     },
                 },
                 "edges": {
                     "e20b": {
                         "subject": "n0",
                         "object": "n2b",
-                        "predicate": "biolink:has_phenotype",
+                        "predicates": "biolink:has_phenotype",
                     },
                 },
             },
@@ -162,14 +162,14 @@ def test_multiedge_or(database):
                 "nodes": {
                     "n0": {},
                     "n1a": {
-                        "id": ["NCBIGene:836"]
+                        "ids": ["NCBIGene:836"]
                     },
                 },
                 "edges": {
                     "e10a": {
                         "subject": "n0",
                         "object": "n1a",
-                        "predicate": "biolink:genetic_association",
+                        "predicates": "biolink:genetic_association",
                     },
                 },
             },
@@ -177,22 +177,22 @@ def test_multiedge_or(database):
                 "nodes": {
                     "n0": {},
                     "n1b": {
-                        "id": "NCBIGene:841"
+                        "ids": "NCBIGene:841"
                     },
                     "n2b": {
-                        "id": "HP:0012592"
+                        "ids": "HP:0012592"
                     },
                 },
                 "edges": {
                     "e10b": {
                         "subject": "n0",
                         "object": "n1b",
-                        "predicate": "biolink:genetic_association",
+                        "predicates": "biolink:genetic_association",
                     },
                     "e20b": {
                         "subject": "n0",
                         "object": "n2b",
-                        "predicate": "biolink:has_phenotype",
+                        "predicates": "biolink:has_phenotype",
                     },
                 },
             },
@@ -229,42 +229,42 @@ def test_or(database):
             {
                 "nodes": {
                     "n1a": {
-                        "id": "NCBIGene:836"
+                        "ids": "NCBIGene:836"
                     },
                 },
                 "edges": {
                     "e10a": {
                         "subject": "n0",
                         "object": "n1a",
-                        "predicate": "biolink:genetic_association",
+                        "predicates": "biolink:genetic_association",
                     },
                 },
             },
             {
                 "nodes": {
                     "n1b": {
-                        "id": "NCBIGene:841"
+                        "ids": "NCBIGene:841"
                     },
                 },
                 "edges": {
                     "e10b": {
                         "subject": "n0",
                         "object": "n1b",
-                        "predicate": "biolink:genetic_association",
+                        "predicates": "biolink:genetic_association",
                     },
                 },
             },
             {
                 "nodes": {
                     "n1c": {
-                        "id": "MONDO:0005148"
+                        "ids": "MONDO:0005148"
                     },
                 },
                 "edges": {
                     "e10c": {
                         "subject": "n1c",
                         "object": "n0",
-                        "predicate": "biolink:has_phenotype",
+                        "predicates": "biolink:has_phenotype",
                     },
                 },
             },
@@ -294,7 +294,7 @@ def test_xor(database):
         {
             "nodes": {
                 "n0": {
-                    "category": "biolink:Disease",
+                    "categories": "biolink:Disease",
                 },
             },
             "edges": {},
@@ -304,30 +304,30 @@ def test_xor(database):
             {
                 "nodes": {
                     "n1": {
-                        "category": "biolink:ChemicalSubstance",
-                        "id": "CHEBI:6801",
+                        "categories": "biolink:ChemicalSubstance",
+                        "ids": "CHEBI:6801",
                     }
                 },
                 "edges": {
                     "e01": {
                         "subject": "n1",
                         "object": "n0",
-                        "predicate": "biolink:treats",
+                        "predicates": "biolink:treats",
                     },
                 },
             },
             {
                 "nodes": {
                     "n2": {
-                        "category": "biolink:ChemicalSubstance",
-                        "id": "CHEBI:136043",
+                        "categories": "biolink:ChemicalSubstance",
+                        "ids": "CHEBI:136043",
                     }
                 },
                 "edges": {
                     "e02": {
                         "subject": "n2",
                         "object": "n0",
-                        "predicate": "biolink:treats",
+                        "predicates": "biolink:treats",
                     },
                 },
             },
@@ -346,18 +346,18 @@ def test_not(database):
         {
             "nodes": {
                 "n0": {
-                    "category": "biolink:ChemicalSubstance",
+                    "categories": "biolink:ChemicalSubstance",
                 },
                 "n1": {
-                    "category": "biolink:Disease",
-                    "id": "MONDO:0005148",
+                    "categories": "biolink:Disease",
+                    "ids": "MONDO:0005148",
                 },
             },
             "edges": {
                 "e01": {
                     "subject": "n0",
                     "object": "n1",
-                    "predicate": "biolink:treats",
+                    "predicates": "biolink:treats",
                 },
             },
         },
@@ -366,17 +366,17 @@ def test_not(database):
             {
                 "nodes": {
                     "n2": {
-                        "category": [
+                        "categories": [
                             "biolink:Disease",
                         ],
-                        "id": "MONDO:0011122"
+                        "ids": "MONDO:0011122"
                     },
                 },
                 "edges": {
                     "e20": {
                         "subject": "n0",
                         "object": "n2",
-                        "predicate": "biolink:treats",
+                        "predicates": "biolink:treats",
                     },
                 },
             },
@@ -400,18 +400,18 @@ def test_not_or(database):
         {
             "nodes": {
                 "n0": {
-                    "category": "biolink:Disease",
+                    "categories": "biolink:Disease",
                 },
                 "n1": {
-                    "category": "biolink:ChemicalSubstance",
-                    "id": "CHEBI:6801",
+                    "categories": "biolink:ChemicalSubstance",
+                    "ids": "CHEBI:6801",
                 },
             },
             "edges": {
                 "e01": {
                     "subject": "n1",
                     "object": "n0",
-                    "predicate": "biolink:treats",
+                    "predicates": "biolink:treats",
                 },
             },
         },
@@ -422,30 +422,30 @@ def test_not_or(database):
                 {
                     "nodes": {
                         "n2": {
-                            "category": "biolink:PhenotypicFeature",
-                            "id": "HP:0012592",
+                            "categories": "biolink:PhenotypicFeature",
+                            "ids": "HP:0012592",
                         },
                     },
                     "edges": {
                         "e20": {
                             "subject": "n0",
                             "object": "n2",
-                            "predicate": "biolink:has_phenotype",
+                            "predicates": "biolink:has_phenotype",
                         },
                     },
                 },
                 {
                     "nodes": {
                         "n3": {
-                            "category": "biolink:Gene",
-                            "id": "NCBIGene:672",
+                            "categories": "biolink:Gene",
+                            "ids": "NCBIGene:672",
                         },
                     },
                     "edges": {
                         "e30": {
                             "subject": "n0",
                             "object": "n3",
-                            "predicate": "biolink:genetic_association",
+                            "predicates": "biolink:genetic_association",
                         },
                     },
                 },

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -6,7 +6,7 @@ from .fixtures import fixture_database
 def test_categories(database):
     """Test multiple categories."""
     qgraph = {
-        "nodes": {"n0": {"category": [
+        "nodes": {"n0": {"categories": [
             "biolink:Disease",
             "biolink:Gene",
         ]}},
@@ -35,8 +35,8 @@ def test_category_none(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "id": "MONDO:0005148",
-                "category": None,
+                "ids": "MONDO:0005148",
+                "categories": None,
             }
         },
         "edges": dict(),
@@ -51,10 +51,10 @@ def test_relation_none(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:Gene",
+                "categories": "biolink:Gene",
             },
         },
         "edges": {
@@ -75,10 +75,10 @@ def test_qnode_addl_null(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:Gene",
+                "categories": "biolink:Gene",
                 "chromosome": None,
             },
         },
@@ -99,17 +99,17 @@ def test_predicate_none(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:Gene",
+                "categories": "biolink:Gene",
             },
         },
         "edges": {
             "e01": {
                 "subject": "n0",
                 "object": "n1",
-                "predicate": None,
+                "predicates": None,
             }
         },
     }
@@ -123,10 +123,10 @@ def test_fancy_key(database):
     qgraph = {
         "nodes": {
             "type-2 diabetes": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:Gene",
+                "categories": "biolink:Gene",
             },
         },
         "edges": {

--- a/tests/test_graph_formats.py
+++ b/tests/test_graph_formats.py
@@ -8,19 +8,19 @@ def test_curie_formats(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "id": [
+                "ids": [
                     "MONDO:0005148",
                     "MONDO:0011122",
                 ],
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:ChemicalSubstance",
+                "categories": "biolink:ChemicalSubstance",
             },
         },
         "edges": {
             "e01": {
-                "predicate": [
+                "predicates": [
                     "biolink:treats",
                 ],
                 "subject": "n1",
@@ -51,15 +51,15 @@ def test_curie_formats(database):
 #     qgraph = {
 #         "nodes": {
 #             "n1": {
-#                 "category": "biolink:PhenotypicFeature",
+#                 "categories": "biolink:PhenotypicFeature",
 #             },
 #             "n0": {
-#                 "category": "biolink:Disease",
-#                 "id": "MONDO:0005148",
+#                 "categories": "biolink:Disease",
+#                 "ids": "MONDO:0005148",
 #             },
 #             "n2": {
-#                 "category": "biolink:ChemicalSubstance",
-#                 "id": [
+#                 "categories": "biolink:ChemicalSubstance",
+#                 "ids": [
 #                     "CHEBI:6801",
 #                 ],
 #             },
@@ -72,12 +72,12 @@ def test_curie_formats(database):
 #             "e01": {
 #                 "subject": "n0",
 #                 "object": "n1",
-#                 "predicate": "INHERITS",
+#                 "predicates": "INHERITS",
 #             },
 #             "e21": {
 #                 "subject": "n2",
 #                 "object": "n1",
-#                 "predicate": [
+#                 "predicates": [
 #                     "WIELDS",
 #                     "FINDS",
 #                 ],
@@ -99,15 +99,15 @@ def test_predicate_list():
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:PhenotypicFeature",
+                "categories": "biolink:PhenotypicFeature",
             },
         },
         "edges": {
             "e01": {
-                "predicate": ["biolink:increases_expression_of", "biolink:decreases_abundance_of"],
+                "predicates": ["biolink:increases_expression_of", "biolink:decreases_abundance_of"],
                 "subject": "n0",
                 "object": "n1",
             },
@@ -123,15 +123,15 @@ def test_single_edge_type_list():
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:PhenotypicFeature",
+                "categories": "biolink:PhenotypicFeature",
             },
         },
         "edges": {
             "e01": {
-                "predicate": ["biolink:increases_abundance_of"],
+                "predicates": ["biolink:increases_abundance_of"],
                 "subject": "n0",
                 "object": "n1",
             },
@@ -147,15 +147,15 @@ def test_invertible():
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:PhenotypicFeature",
+                "categories": "biolink:PhenotypicFeature",
             },
         },
         "edges": {
             "e01": {
-                "predicate": "biolink:has_phenotype",
+                "predicates": "biolink:has_phenotype",
                 "subject": "n0",
                 "object": "n1",
             },
@@ -171,8 +171,8 @@ def test_curie_int():
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
-                "id": 12,
+                "categories": "biolink:Disease",
+                "ids": 12,
             },
         },
         "edges": dict(),

--- a/tests/test_invalid.py
+++ b/tests/test_invalid.py
@@ -63,7 +63,7 @@ def test_invalid_node():
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:BiologicalEntity",
+                "categories": "biolink:BiologicalEntity",
                 "dict": {"a": 1},
             },
         },

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -11,14 +11,14 @@ def test_symmetric(database):
         "nodes": {
             "n0": {},
             "n1": {
-                "id": "NCBIGene:836"
+                "ids": "NCBIGene:836"
             },
         },
         "edges": {
             "e10a": {
                 "subject": "n1",
                 "object": "n0",
-                "predicate": "biolink:genetic_association",
+                "predicates": "biolink:genetic_association",
             },
         },
     }
@@ -33,7 +33,7 @@ def test_any(database):
         "nodes": {
             "n0": {},
             "n1": {
-                "id": "NCBIGene:836"
+                "ids": "NCBIGene:836"
             },
         },
         "edges": {
@@ -53,7 +53,7 @@ def test_sub(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "id": "MONDO:0004993",
+                "ids": "MONDO:0004993",
             },
             "n1": {},
         },
@@ -61,7 +61,7 @@ def test_sub(database):
             "e10": {
                 "subject": "n0",
                 "object": "n1",
-                "predicate": "biolink:genetic_association",
+                "predicates": "biolink:genetic_association",
             },
         },
     }
@@ -75,7 +75,7 @@ def test_inverse(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "id": "NCBIGene:672",
+                "ids": "NCBIGene:672",
             },
             "n1": {},
         },
@@ -83,7 +83,7 @@ def test_inverse(database):
             "e10": {
                 "subject": "n0",
                 "object": "n1",
-                "predicate": "biolink:gene_associated_with_condition",
+                "predicates": "biolink:gene_associated_with_condition",
             },
         },
     }

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -112,7 +112,7 @@ def test_publications(database):
     attributes = list(edges.values())[0]["attributes"]
     assert len(attributes) == 1
     assert attributes[0] == {
-        "name": "publications",
-        "type": "EDAM:data_0971",
+        "original_attribute_name": "publications",
+        "attribute_type_id": "EDAM:data_0971",
         "value": ["xxx"],
     }

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -8,7 +8,7 @@ def test_numeric(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Gene",
+                "categories": "biolink:Gene",
                 "length": 277,
             },
         },
@@ -33,7 +33,7 @@ def test_string(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Gene",
+                "categories": "biolink:Gene",
                 "chromosome": "17",
             },
         },
@@ -58,17 +58,17 @@ def test_bool(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:ChemicalSubstance",
+                "categories": "biolink:ChemicalSubstance",
             },
             "n1": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
         },
         "edges": {
             "e01": {
                 "subject": "n0",
                 "object": "n1",
-                "predicate": "biolink:treats",
+                "predicates": "biolink:treats",
                 "fda_approved": True,
             },
         },
@@ -92,10 +92,10 @@ def test_publications(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "id": "NCBIGene:836",
+                "ids": "NCBIGene:836",
             },
             "n1": {
-                "id": "NCBIGene:841",
+                "ids": "NCBIGene:841",
             },
         },
         "edges": {

--- a/tests/test_query_args.py
+++ b/tests/test_query_args.py
@@ -8,18 +8,18 @@ def test_skip_limit(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
-                "id": "MONDO:0005148",
+                "categories": "biolink:Disease",
+                "ids": "MONDO:0005148",
             },
             "n1": {
-                "category": "biolink:ChemicalSubstance",
+                "categories": "biolink:ChemicalSubstance",
             },
         },
         "edges": {
             "e01": {
                 "subject": "n1",
                 "object": "n0",
-                "predicate": "biolink:treats",
+                "predicates": "biolink:treats",
             },
         },
     }
@@ -45,16 +45,16 @@ def test_max_connectivity(database):
     qgraph = {
         "nodes": {
             "n0": {
-                "category": "biolink:Disease",
+                "categories": "biolink:Disease",
             },
             "n1": {
-                "category": "biolink:ChemicalSubstance",
-                "id": "CHEBI:6801",
+                "categories": "biolink:ChemicalSubstance",
+                "ids": "CHEBI:6801",
             },
         },
         "edges": {
             "e01": {
-                "predicate": "biolink:treats",
+                "predicates": "biolink:treats",
                 "subject": "n1",
                 "object": "n0",
             },
@@ -80,17 +80,17 @@ def test_use_hints():
     qgraph = {
         "nodes": {
             "n0": {
-                "id": [
+                "ids": [
                     "NCBIGene:841",
                 ],
-                "category": "biolink:Gene",
+                "categories": "biolink:Gene",
             },
             "n1": {
             },
         },
         "edges": {
             "e01": {
-                "predicate": [
+                "predicates": [
                     "biolink:molecularly_interacts_with",
                     "biolink:increases_expression_of",
                 ],


### PR DESCRIPTION
Note that we still allow ids, categories, and predicates to be strings, even through TRAPI does not. So many of our test query graphs are not officially compliant. In other words, we support a superset of TRAPI.