### PR TITLE
Adding more mappings for edge provenance attribute

### DIFF
--- a/reasoner/attribute_types.json
+++ b/reasoner/attribute_types.json
@@ -1,3 +1,4 @@
 {
-    "publications": "EDAM:data_0971"
+    "publications": "EDAM:data_0971",
+    "biolink:original_knowledge_source": "biolink:original_knowledge_source"
 }


### PR DESCRIPTION
In new KP (plater)  builds we are going to put in a neo4j attribute on edges with the name  and value like:
`biolink:original_knowledge_source` : infores:*

Making this PR so reasoner transplier can map that neo4j value  to a porper attribute_type_id when returning.