### PR TITLE
Expedite many-CURIE queries

### DIFF
--- a/reasoner_transpiler/matching.py
+++ b/reasoner_transpiler/matching.py
@@ -65,13 +65,13 @@ class NodeReference():
         if isinstance(curie, list) and len(curie) == 1:
             curie = curie[0]
         if isinstance(curie, list):
-            self._filters.append(" OR ".join([
-                "{0}.id = {1}".format(
-                    self.name,
+            self._filters.append("{0}.id in [{1}]".format(
+                self.name,
+                ", ".join([
                     cypher_prop_string(ci)
-                )
-                for ci in curie
-            ]))
+                    for ci in curie
+                ])
+            ))
         elif curie is not None:
             # coerce to a string
             props["id"] = str(curie)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="reasoner-transpiler",
-    version="1.8.0",
+    version="1.8.1",
     author="Patrick Wang",
     author_email="patrick@covar.com",
     url="https://github.com/ranking-agent/reasoner-transpiler",


### PR DESCRIPTION
For qnode ids, use "a IN [x, y]" instead of "a = x OR a = y".