### PR TITLE
Ignore qnode/qedge constraints

### DIFF
--- a/reasoner_transpiler/matching.py
+++ b/reasoner_transpiler/matching.py
@@ -85,7 +85,7 @@ class NodeReference():
         props.update(
             (key, value)
             for key, value in node.items()
-            if key not in ("name", "is_set")
+            if key not in ("name", "is_set", "constraints")
         )
 
         self.prop_string = "{" + ", ".join([

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="reasoner-transpiler",
-    version="1.10.0",
+    version="1.10.1",
     author="Patrick Wang",
     author_email="patrick@covar.com",
     url="https://github.com/ranking-agent/reasoner-transpiler",

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -116,3 +116,18 @@ def test_publications(database):
         "attribute_type_id": "EDAM:data_0971",
         "value": ["xxx"],
     }
+
+
+def test_constraints(database):
+    """Test querying with 'constraints' property."""
+    qgraph = {
+        "nodes": {
+            "n0": {
+                "categories": "biolink:Gene",
+                "constraints": [],
+            },
+        },
+        "edges": {},
+    }
+    output = list(database.run(get_query(qgraph)))[0]
+    assert len(output["results"]) == 3


### PR DESCRIPTION
This is a patch to prevent constraints from causing problems, until we can handle them properly.