### PR TITLE
Using index for multi-label nodes

### DIFF
--- a/reasoner_transpiler/matching.py
+++ b/reasoner_transpiler/matching.py
@@ -50,6 +50,7 @@ class NodeReference():
         if isinstance(category, list) and len(category) == 1:
             category = category[0]
         if isinstance(category, list):
+            self.labels = ['biolink:NamedThing']
             self._filters.append(" OR ".join([
                 "{1} in labels({0})".format(
                     self.name,

--- a/tests/initialize_db.py
+++ b/tests/initialize_db.py
@@ -49,7 +49,7 @@ def main(hash: str = None):
         session.run("MATCH (m) DETACH DELETE m")
         session.run(f"LOAD CSV WITH HEADERS FROM \"{node_file}\" "
                     "AS row "
-                    "CALL apoc.create.node([row.category], apoc.map.merge({"
+                    "CALL apoc.create.node([row.category, 'biolink:NamedThing'], apoc.map.merge({"
                     "name: row.name, id: row.id"
                     "}, apoc.convert.fromJsonMap(row.props))) YIELD node "
                     "RETURN count(*)")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -164,3 +164,39 @@ def test_backwards_predicate(database):
     cypher = get_query(qgraph)
     output = list(database.run(cypher))[0]
     assert len(output["results"]) == 3
+
+
+def test_index_usage_single_labels():
+    """
+    Test when using single labels, checks if id index is with the node type is used
+    """
+    qgraph = {
+        "nodes": {
+            "n0": {
+                "ids": ["MONDO:0005148"],
+                "categories": "biolink:Disease",
+            }
+        },
+        "edges": {}
+    }
+    cypher = get_query(qgraph, **{"use_hints": True})
+    # superclass node_id is suffixed with _superclass
+    assert "USING INDEX `n0_superclass`:`biolink:Disease`(id)" in cypher
+
+
+def test_index_usage_multiple_labels():
+    """
+    When multiple labels are used `biolink:NamedThing` index to be used
+    """
+    qgraph = {
+        "nodes": {
+            "n0": {
+                "ids": ["MONDO:0005148"],
+                "categories": ["biolink:Disease", "biolink:PhenotypicFeature"],
+            }
+        },
+        "edges": {}
+    }
+    cypher = get_query(qgraph, **{"use_hints": True})
+    # superclass node_id is suffixed with _superclass
+    assert "USING INDEX `n0_superclass`:`biolink:NamedThing`(id)" in cypher


### PR DESCRIPTION
 When nodes with multiple labels are presented, neo4j indexes are not used. This seems to be the limitation of neo4j syntax where multiple indexes of a single var is not allowed. For eg.

```
MATCH (a)-[e]->(b:`biolink:SmallMolecule`) 
USING INDEX a:`biolink:Protein`(id)
USING INDEX a:`biolink:Gene`(id)
where ( "bioink:Protein" in labels(a) or "biolink:Gene" in labels(a) ) AND a.id in ['NCBIGene:10765', 'NCBIGene:8452', 'NCBIGene:8065', 'NCBIGene:22836'] 
Return * 
```

To enable this we can tweak the query as 

```
MATCH (a:`biolink:NamedThing`)-[e]->(b:`biolink:SmallMolecule`) 
USING INDEX a:`biolink:NamedThing`(id)
where ( "bioink:Protein" in labels(a) or "biolink:Gene" in labels(a) ) AND a.id in ['NCBIGene:10765', 'NCBIGene:8452', 'NCBIGene:8065', 'NCBIGene:22836'] 
Return * 
```
For single typed TRAPI Query graph nodes, the existing scheme works since indexes for single labels would be used, but for multi-labels , previously generated query works but runs very slow.


 