### PR TITLE
pop category

### DIFF
--- a/reasoner_transpiler/matching.py
+++ b/reasoner_transpiler/matching.py
@@ -309,7 +309,7 @@ def match_query(qgraph, subclass=True, **kwargs):
         superclasses = {
             qnode_id + "_superclass": {
                 "ids": qnode.pop("ids"),
-                "categories": qnode.get("categories", None),
+                "categories": qnode.pop("categories", None),
                 "_return": False,
             }
             for qnode_id, qnode in qgraph["nodes"].items()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="reasoner-transpiler",
-    version="1.10.4",
+    version="1.10.5",
     author="Patrick Wang",
     author_email="patrick@covar.com",
     url="https://github.com/ranking-agent/reasoner-transpiler",

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -39,6 +39,31 @@ def test_onehop_subclass(database):
     output = list(database.run(query))[0]
     assert len(output['results']) == 9
 
+def test_onehop_subclass_categories():
+    """Test one-hop subclass query."""
+    qgraph = {
+        "nodes": {
+            "n0": {"ids": ["HP:0011015"], "categories": ["biolink:PhenotypicFeature"]},
+            "n1": {},
+        },
+        "edges": {
+            "e01": {
+                "subject": "n1",
+                "object": "n0",
+                "predicates": ["biolink:treats"]
+            },
+        },
+    }
+    query = get_query(qgraph)
+    #make sure that the class (PhenotypicFeature) has been removed from n0
+    clause = query.split('WHERE')[0]
+    elements = clause.split('-')
+    checked = False
+    for element in elements:
+        if 'n0' in element:
+            checked = True
+            assert 'PhenotypicFeature' not in element
+    assert checked
 
 def test_backward_subclass(database):
     """Test pinned-object one-hop subclass query."""


### PR DESCRIPTION
When we have a node with categories, we make a new superclass node.  The ID pops to the new superclass node, and the category gets added to it.  But the category should also be popped (i.e. removed from the original node). 

This is because we might have a situation (especially between diseases and phenotypes) where there is mixture of types across the subclass hierarchy.  In particular there are Phenotype nodes like "Abnormal glucose" with subclass nodes like "hyperglycemia" and "hypoglycemia".  There are disease terms for the latter so they get called a disease, but there's no such disease term for the "Abnormal glucose" term so it gets called a phenotype.