### PR TITLE
Trapi 13

### DIFF
--- a/reasoner_transpiler/matching.py
+++ b/reasoner_transpiler/matching.py
@@ -226,12 +226,13 @@ class EdgeReference():
                     _object,
                 ),
             ]))
-
+        constraints = ["attribute_constraints", "qualifier_constraints"]
+        other_non_prop_attributes = ["name", "knowledge_type"]
         props = {}
         props.update(
             (key, value)
             for key, value in edge.items()
-            if key not in ("name", "constraints") and not key.startswith("_")
+            if key not in set(constraints + other_non_prop_attributes) and not key.startswith("_")
         )
 
         self.prop_string = " {" + ", ".join([

--- a/reasoner_transpiler/matching.py
+++ b/reasoner_transpiler/matching.py
@@ -309,7 +309,7 @@ def match_query(qgraph, subclass=True, **kwargs):
         superclasses = {
             qnode_id + "_superclass": {
                 "ids": qnode.pop("ids"),
-                "categories": qnode.get("categories", None),
+                "categories": qnode.pop("categories", None),
                 "_return": False,
             }
             for qnode_id, qnode in qgraph["nodes"].items()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="reasoner-transpiler",
-    version="1.10.5",
+    version="1.10.6",
     author="Patrick Wang",
     author_email="patrick@covar.com",
     url="https://github.com/ranking-agent/reasoner-transpiler",

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -134,7 +134,7 @@ def test_constraints(database):
             "e01": {
                 "subject": "n0",
                 "object": "n1",
-                "constraints": [],
+                "attribute_constraints": [],
             },
         },
     }

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -39,6 +39,31 @@ def test_onehop_subclass(database):
     output = list(database.run(query))[0]
     assert len(output['results']) == 9
 
+def test_onehop_subclass_categories():
+    """Test one-hop subclass query."""
+    qgraph = {
+        "nodes": {
+            "n0": {"ids": ["HP:0011015"], "categories": ["biolink:PhenotypicFeature"]},
+            "n1": {},
+        },
+        "edges": {
+            "e01": {
+                "subject": "n1",
+                "object": "n0",
+                "predicates": ["biolink:treats"]
+            },
+        },
+    }
+    query = get_query(qgraph)
+    #make sure that the class (PhenotypicFeature) has been removed from n0
+    clause = query.split('WHERE')[0]
+    elements = clause.split('-')
+    checked = False
+    for element in elements:
+        if 'n0' in element:
+            checked = True
+            assert 'PhenotypicFeature' not in element
+    assert checked
 
 def test_backward_subclass(database):
     """Test pinned-object one-hop subclass query."""


### PR DESCRIPTION
- Handles addition of `attribute_constraint` and `qualifier_constraint` keys in edges.
- Due to the complexity in different operations for trapi constraints (matches, eq, deep_eq, gt , lt) . Those will be handled in python upstream of this lib. This for now ignores all trapi constraints. 